### PR TITLE
Change font attribute name

### DIFF
--- a/src/main/res/values/attrs.xml
+++ b/src/main/res/values/attrs.xml
@@ -5,7 +5,7 @@
     <attr format="boolean" name="justifyText"/>
 
     <!-- Attributes for custom font-->
-    <attr format="enum" name="font">
+    <attr format="enum" name="typeface">
       <enum name="aller_bold" value="0"/>
       <enum name="aller_bold_italic" value="1"/>
       <enum name="aller_display" value="2"/>


### PR DESCRIPTION
This is so that it conforms with Android O. See https://stackoverflow.com/questions/45646103/android-support-library-build-v26-x-x-build-error-attribute-font-already-defi